### PR TITLE
Hex dma qurt mutex init

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -105,6 +105,7 @@ struct halide_mutex {
  * re-zeros the memory.
  */
 //@{
+extern void halide_mutex_init(struct halide_mutex *mutex);
 extern void halide_mutex_lock(struct halide_mutex *mutex);
 extern void halide_mutex_unlock(struct halide_mutex *mutex);
 extern void halide_mutex_destroy(struct halide_mutex *mutex);

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -38,6 +38,9 @@ WEAK halide_thread *halide_spawn_thread(void (*f)(void *), void *closure) {
 WEAK void halide_mutex_destroy(halide_mutex *mutex_arg) {
 }
 
+WEAK void halide_mutex_init(halide_mutex *mutex) {
+}
+
 WEAK void halide_mutex_lock(halide_mutex *mutex) {
 }
 

--- a/src/runtime/gcd_thread_pool.cpp
+++ b/src/runtime/gcd_thread_pool.cpp
@@ -142,6 +142,9 @@ WEAK void halide_mutex_destroy(halide_mutex *mutex_arg) {
     }
 }
 
+WEAK void halide_mutex_init(halide_mutex *mutex_arg) {
+}
+
 WEAK void halide_mutex_lock(halide_mutex *mutex_arg) {
     gcd_mutex *mutex = (gcd_mutex *)mutex_arg;
     dispatch_once_f(&mutex->once, mutex, init_mutex);

--- a/src/runtime/posix_threads.cpp
+++ b/src/runtime/posix_threads.cpp
@@ -62,6 +62,9 @@ WEAK void halide_join_thread(struct halide_thread *thread_arg) {
     free(t);
 }
 
+WEAK void halide_mutex_init(halide_mutex *mutex) {
+}
+
 WEAK void halide_mutex_lock(halide_mutex *mutex) {
     pthread_mutex_lock(mutex);
 }

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -10,6 +10,7 @@ extern "C" {
 // Returns the address of the global halide_profiler state
 WEAK halide_profiler_state *halide_profiler_get_state() {
     static halide_profiler_state s = {{{0}}, 1, 0, 0, 0, 0, NULL, false};
+    halide_mutex_init(&(s.lock));
     return &s;
 }
 }

--- a/src/runtime/qurt_thread_pool.cpp
+++ b/src/runtime/qurt_thread_pool.cpp
@@ -3,7 +3,8 @@
 
 using namespace Halide::Runtime::Internal::Qurt;
 
-#define QURT_MUTEX_INIT_FLAG   0xFACEFACEFACEFACE         // some pattern value
+//Pattern to check if mutex is initialized 
+#define QURT_MUTEX_INIT_FLAG   0xFACEFACEFACEFACE 
 
 extern "C" {
 extern void *memalign(size_t, size_t);
@@ -72,7 +73,7 @@ WEAK void halide_mutex_init(halide_mutex *mutex_arg) {
 
 WEAK void halide_mutex_lock(halide_mutex *mutex_arg) {
     qurt_mutex_wrapper_t *pmutex = (qurt_mutex_wrapper_t *)mutex_arg;
-    halide_assert(0, pmutex->init_flag == QURT_MUTEX_INIT_FLAG);             // check mutex is initialized
+    halide_assert(0, pmutex->init_flag == QURT_MUTEX_INIT_FLAG);   //check mutex is initialized
     qurt_mutex_lock((qurt_mutex_t *)&pmutex->mutex);
 }
 

--- a/src/runtime/qurt_thread_pool.cpp
+++ b/src/runtime/qurt_thread_pool.cpp
@@ -3,8 +3,7 @@
 
 using namespace Halide::Runtime::Internal::Qurt;
 
-//Pattern to check if mutex is initialized 
-#define QURT_MUTEX_INIT_FLAG   0xFACEFACEFACEFACE 
+#define QURT_MUTEX_INIT_FLAG   0xFACEFACEFACEFACE         // some pattern value
 
 extern "C" {
 extern void *memalign(size_t, size_t);
@@ -19,9 +18,11 @@ int halide_host_cpu_count() {
     return 4;
 }
 
+//Wraooer that envelopes and init_flag for initialization 
 typedef struct {
-    uint64_t init_flag;
     qurt_mutex_t mutex;
+    uint64_t init_flag;
+    uint64_t _dummy[5]; 
 } qurt_mutex_wrapper_t;
 
 namespace {
@@ -73,7 +74,8 @@ WEAK void halide_mutex_init(halide_mutex *mutex_arg) {
 
 WEAK void halide_mutex_lock(halide_mutex *mutex_arg) {
     qurt_mutex_wrapper_t *pmutex = (qurt_mutex_wrapper_t *)mutex_arg;
-    halide_assert(0, pmutex->init_flag == QURT_MUTEX_INIT_FLAG);   //check mutex is initialized
+    //check here if mutex is initialized 
+    halide_assert(0, pmutex->init_flag == QURT_MUTEX_INIT_FLAG); 
     qurt_mutex_lock((qurt_mutex_t *)&pmutex->mutex);
 }
 
@@ -118,7 +120,8 @@ extern "C" {
 WEAK int halide_do_par_for(void *user_context,
                            halide_task_t task,
                            int min, int size, uint8_t *closure) {
-    qurt_mutex_t *mutex = (qurt_mutex_t *)(&work_queue.mutex);
+    // Do not initialize here. Initialize in constructor  
+    /*qurt_mutex_t *mutex = (qurt_mutex_t *)(&work_queue.mutex);
     if (!work_queue.initialized) {
         // The thread pool asssumes that a zero-initialized mutex can
         // be locked. Not true on hexagon, and there doesn't seem to
@@ -126,8 +129,8 @@ WEAK int halide_do_par_for(void *user_context,
         // safe to assume that the first call to halide_do_par_for is
         // done by the main thread, so there's no race condition on
         // initializing this mutex.
-        qurt_mutex_init(mutex);
-    }
+       // qurt_mutex_init(mutex);
+    }*/
     return halide_default_do_par_for(user_context, task, min, size, (uint8_t *)closure);
 }
 

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -124,6 +124,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_msan_annotate_buffer_is_initialized_as_destructor,
     (void *)&halide_msan_annotate_memory_is_initialized,
     (void *)&halide_mutex_destroy,
+    (void *)&halide_mutex_init,
     (void *)&halide_mutex_lock,
     (void *)&halide_mutex_unlock,
     (void *)&halide_opencl_detach_cl_mem,

--- a/src/runtime/scoped_mutex_lock.h
+++ b/src/runtime/scoped_mutex_lock.h
@@ -10,6 +10,7 @@ struct ScopedMutexLock {
     halide_mutex *mutex;
 
     ScopedMutexLock(halide_mutex *mutex) __attribute__((always_inline)) : mutex(mutex) {
+        halide_mutex_init(mutex);
         halide_mutex_lock(mutex);
     }
 

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -52,6 +52,10 @@ struct work_queue_t {
     // whether the thread pool has been initialized.
     bool shutdown, initialized;
 
+    work_queue_t() {
+        halide_mutex_init(&mutex);
+    }
+
     bool running() {
         return !shutdown;
     }

--- a/src/runtime/windows_threads.cpp
+++ b/src/runtime/windows_threads.cpp
@@ -79,6 +79,9 @@ WEAK void halide_mutex_destroy(halide_mutex *mutex_arg) {
     }
 }
 
+WEAK void halide_mutex_init(halide_mutex *mutex_arg) {
+}
+
 WEAK void halide_mutex_lock(halide_mutex *mutex_arg) {
     windows_mutex *mutex = (windows_mutex *)mutex_arg;
     InitOnceExecuteOnce(&mutex->once, init_mutex, mutex, NULL);


### PR DESCRIPTION
Problem: halide_mutex_init() is not initializing the mutex variable and is causing problems as qurt_mutex_lock assumes the mutex is already initialized 
This PR has the changes to do a qurt_mutex_init inside the halide_mutex_init() and and we have dummy functions for non hexagon targets

We have to do an explicit checking whether mutex variable is initialized or not with a magic value  because of ScopedMutexLock being used as a local variable with global mutex parameter.

TODO: The current solution is not thread safe for multi-pipelines or when threading is done at APP level. Working on for the proper fix